### PR TITLE
add configuration for build x64 version for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - LIN64BIN=golkv373-$TRAVIS_TAG-linux64
     - WIN32BIN=golkv373-$TRAVIS_TAG-win32.exe
+    - WIN64BIN=golkv373-$TRAVIS_TAG-win64.exe
 
 jobs:
   include:
@@ -15,6 +16,7 @@ jobs:
         - echo "Building and Deploying to GitHub releases ..."
         - go build -o $LIN64BIN
         - GOOS=windows GOARCH=386 go build -o $WIN32BIN
+        - GOOS=windows GOARCH=amd64 go build -o $WIN64BIN
         - find .
       deploy:
         provider: releases
@@ -23,6 +25,7 @@ jobs:
         file:
           - $LIN64BIN
           - $WIN32BIN
+          - $WIN64BIN
         on:
           tags: true
 


### PR DESCRIPTION
Added some configurations to `.travis.yml` for Windows x64 platform.
This x64 version can be downloaded [from my repository](https://github.com/kurokobo/golkv373/releases/tag/v0.5.2) and of course the binary works perfectly in my Windows PC. 

I couldn't decide whether to create PR to `master` or `dev`, but I decided to use `master` because `dev` doesn't seem to be used these days.

Please feel free to reject if the merge is difficult. Thank you for your great work :)